### PR TITLE
Add options to allow scripts to show GUIs

### DIFF
--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -9,5 +9,15 @@
     "environment_directory": "~\\Anaconda3\\envs\\",
 
     // configuration is the path to conda's configuration file
-    "configuration": "~\\.condarc"
+    "configuration": "~\\.condarc",
+
+    // when true, the scripts will be run through the shell
+    // If your code has a GUI (e.g. a matplotlib plot),
+    // this needs to be true, otherwise Windows suppresses it.
+    "run_through_shell": false,
+
+    // when true, the script execution will be handed over to
+    // the pythonw executable, instead of python
+    "use_pythonw": false,
+
 }

--- a/commands.py
+++ b/commands.py
@@ -461,13 +461,18 @@ class ExecuteCondaEnvironmentCommand(CondaCommand):
         """
         try:
             environment = self.project_data['conda_environment']
+            use_pythonw = self.settings.get('use_pythonw', False)
+            run_through_shell = self.settings.get('run_through_shell', False)
+
+            python_executable = 'pythonw' if use_pythonw else 'python'
 
             if sys.platform == 'win32':
-                executable_path = '{}\\python' .format(environment)
+                executable_path = '{}\\{}' .format(environment, python_executable)
             else:
-                executable_path = '{}/bin/python' .format(environment)
+                executable_path = '{}/bin/{}' .format(environment, python_executable)
 
             kwargs['cmd'][0] = os.path.normpath(executable_path)
+            kwargs['shell'] = run_through_shell
 
         except KeyError:
             pass


### PR DESCRIPTION
There are two new options on the package settings:

 - `run_through_shell`: `true`/`false` indicating if the script is to be run through the shell or not
 - `use_pythonw`: `true` to use `pythonw`, otherwise `false` to use `python` executable.

Both options default to `false`, hence not changing previous behavior unless overwritten.

This should fix #8, and by extension, the [bug report](https://github.com/compas-dev/compas/issues/263) that triggered this on a completely different repository.