### PR TITLE
Fixes windows PATH issue causing import errors with some packages.

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -476,7 +476,7 @@ class ExecuteCondaEnvironmentCommand(CondaCommand):
         Required to address PATH issues that prevent some libraries from finding
         compiled dependencies.
         """
-        if sys.platform == 'win32' and self.conda_version > (4, 6):
+        if sys.platform == 'win32' and self.conda_version >= (4, 6):
             env_path = self.project_data['conda_environment']
             bin_path = os.path.join(env_path, 'Library', 'bin')
             os.environ['PATH'] = os.pathsep.join((bin_path, self.os_env_path))

--- a/commands.py
+++ b/commands.py
@@ -1,5 +1,4 @@
 import os
-import re
 import subprocess
 import sys
 
@@ -463,16 +462,17 @@ class ExecuteCondaEnvironmentCommand(CondaCommand):
         Returns this system's conda version in the form (major, minor, micro).
         """
         response = subprocess.check_output(
-            [self.executable, '-m', 'conda', '--version'], 
-            startupinfo=self.startupinfo).decode().strip()        
-        return tuple(int(m) for m in re.findall(r'\d+', response))
-   
+            [self.executable, '-m', 'conda', 'info', '--json'],
+            startupinfo=self.startupinfo)
+        conda_info = json.loads(response.decode())
+        return tuple(int(n) for n in conda_info['conda_version'].split('.'))
+
     def __enter__(self):
         """
         Temporarily modifies os.environ['PATH'] to include the target
         environment's /bin directory if this is a Windows system using a conda
         version >= 4.6.
-        
+
         Required to address PATH issues that prevent some libraries from finding
         compiled dependencies.
         """

--- a/commands.py
+++ b/commands.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import sys
 
@@ -454,6 +455,36 @@ class RemoveCondaChannelCommand(CondaCommand):
 class ExecuteCondaEnvironmentCommand(CondaCommand):
     """Override Sublime Text's default ExecCommand with a targeted build."""
 
+    os_env_path = os.environ['PATH']
+
+    @property
+    def conda_version(self):
+        """
+        Returns this system's conda version in the form (major, minor, micro).
+        """
+        response = subprocess.check_output(
+            [self.executable, '-m', 'conda', '--version'], 
+            startupinfo=self.startupinfo).decode().strip()        
+        return tuple(int(m) for m in re.findall(r'\d+', response))
+   
+    def __enter__(self):
+        """
+        Temporarily modifies os.environ['PATH'] to include the target
+        environment's /bin directory if this is a Windows system using a conda
+        version >= 4.6.
+        
+        Required to address PATH issues that prevent some libraries from finding
+        compiled dependencies.
+        """
+        if sys.platform == 'win32' and self.conda_version > (4, 6):
+            env_path = self.project_data['conda_environment']
+            bin_path = os.path.join(env_path, 'Library', 'bin')
+            os.environ['PATH'] = os.pathsep.join((bin_path, self.os_env_path))
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        os.environ['PATH'] = self.os_env_path
+
     def run(self, **kwargs):
         """Run the current Python file with the conda environment's Python executable.
 
@@ -482,4 +513,5 @@ class ExecuteCondaEnvironmentCommand(CondaCommand):
         if kwargs.get('kill') is not None:
             kwargs = {'kill': True}
 
-        self.window.run_command('exec', kwargs)
+        with self:
+            self.window.run_command('exec', kwargs)


### PR DESCRIPTION
Addresses #12 

If `/env/Library/bin` is not on the Windows PATH, packages are unable to load dependencies in that directory.  Issue is addressed by extending `ExecuteCondaEnvironmentCommand` with context manager protocols that temporarily prepend the required directory to `os.environ['PATH']` prior to running the target file. The `PATH` entry is reset to its original value once target file exits.

The patch is only applied to Windows environments where conda version > 4.6

I don't know if using regex to parse conda's version is the best way to handle retrieving the desired information, but I felt it was better then looking for the meta-data file.  Please let me know if an alternative is preferred. 