### PR TITLE
Use edit_settings for viewing and modifying package settings

### DIFF
--- a/Conda (Linux).sublime-settings
+++ b/Conda (Linux).sublime-settings
@@ -1,4 +1,4 @@
-// Default settings for sublime-text-conda:
+// Default Linux settings for sublime-text-conda:
 {
     // executable is the path to anaconda's python
     // this python executable is used in order to find conda

--- a/Conda (OSX).sublime-settings
+++ b/Conda (OSX).sublime-settings
@@ -1,0 +1,13 @@
+// Default OSX settings for sublime-text-conda:
+{
+    // executable is the path to anaconda's python
+    // this python executable is used in order to find conda
+    "executable": "~/anaconda3/bin/python3",
+
+    // Directory in which the conda envs are stored
+    // Default location is the user's home directory
+    "environment_directory": "~/anaconda3/envs/",
+
+    // configuration is the path to conda's configuration file
+    "configuration": "~/.condarc"
+}

--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -1,4 +1,4 @@
-// Default settings for sublime-text-conda:
+// Default Windows settings for sublime-text-conda:
 {
     // executable is the path to anaconda's python
     // this python executable is used in order to find conda
@@ -18,6 +18,5 @@
 
     // when true, the script execution will be handed over to
     // the pythonw executable, instead of python
-    "use_pythonw": false,
-
+    "use_pythonw": false
 }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -9,36 +9,15 @@
         "children": [{
             "caption": "Conda",
             "children": [
-                    {
-                        "caption": "Settings – Default",
-                        "command": "open_file",
-                        "args": { "file": "${packages}/Conda/Conda.sublime-settings", "platform": "Linux" }
-                    },
-                    {
-                        "caption": "Settings – User",
-                        "command": "open_file",
-                        "args": { "file": "${packages}/User/Conda.sublime-settings", "platform": "Linux"}
-                    },
-                    {
-                        "caption": "Settings – Default",
-                        "command": "open_file",
-                        "args": { "file": "${packages}/Conda/Conda.sublime-settings", "platform": "OSX" }
-                    },
-                    {
-                        "caption": "Settings – User",
-                        "command": "open_file",
-                        "args": { "file": "${packages}/User/Conda.sublime-settings", "platform": "OSX"}
-                    },
-                    {
-                        "caption": "Settings – Default",
-                        "command": "open_file",
-                        "args": { "file": "${packages}/Conda/Conda (Windows).sublime-settings", "platform": "Windows" }
-                    },
-                    {
-                        "caption": "Settings – User",
-                        "command": "open_file",
-                        "args": { "file": "${packages}/User/Conda (Windows).sublime-settings", "platform": "Windows"}
-                    }
+                {
+                    "caption": "Settings",
+                    "command": "edit_settings",
+                    "args":
+                     {
+                         "base_file": "${packages}/Conda/Conda (${platform}).sublime-settings",
+                         "default": "{\n\t$0\n}\n"
+                     }
+                }
             ]
         }]
     }]


### PR DESCRIPTION
Addresses #22 

Consolidated 'Settings - Default' and 'Settings - User' to a single
entry, 'Settings'.

Settings files are now opened using the `edit_settings` command, which
opens both Default and User settings in separate columns.

Command definitions were reduced to a single item by making use of the
`${platform}` environment variable, which, when expanded, provides the
host system's platform name.