### PR TITLE
Add REPL function

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,6 +4,7 @@
     { "caption": "Conda: List Environments", "command": "list_conda_environment" },
     { "caption": "Conda: Activate Environment", "command": "activate_conda_environment" },
     { "caption": "Conda: Deactivate Environment", "command": "deactivate_conda_environment" },
+    { "caption": "Conda: Open REPL", "command": "open_conda_repl" },
     { "caption": "Conda: List Packages", "command": "list_conda_package" },
     { "caption": "Conda: Install Package", "command": "install_conda_package" },
     { "caption": "Conda: Remove Package", "command": "remove_conda_package" },

--- a/commands.py
+++ b/commands.py
@@ -238,6 +238,40 @@ class DeactivateCondaEnvironmentCommand(CondaCommand):
                 sublime.status_message('No active conda environment')
 
 
+class OpenCondaReplCommand(CondaCommand):
+    """Open a REPL tab within the activated Conda environment."""
+
+    def run(self, open_file='$file'):
+        """Display 'Conda: Open REPL' in Sublime Text's command palette.
+
+        When 'Conda: Open REPL' is clicked by the user, a new tab is opened with a REPL of the opened file in the current environment.
+        """
+        environment_path = self.project_data['conda_environment']
+        executable_path = "{}\\{}".format(os.path.expanduser(environment_path), "python")
+        environment = self.retrieve_environment_name(environment_path)
+
+        cmd_list = [executable_path,  '-u', '-i']
+
+        if open_file:
+            cmd_list.append(open_file)
+
+        self.repl_open(cmd_list, environment)
+
+    def repl_open(self, cmd_list, environment):
+        """Open a SublimeREPL using provided commands"""
+        self.window.run_command(
+            'repl_open', {
+                'encoding': 'utf8',
+                'type': 'subprocess',
+                'cmd': cmd_list,
+                'cwd': '$file_path',
+                'syntax': 'Packages/Python/Python.tmLanguage',
+                'view_id': '*REPL* [python]',
+                'external_id': environment,
+            }
+        )
+
+
 class ListCondaPackageCommand(CondaCommand):
     """Contains all of the methods needed to list all installed packages."""
 
@@ -512,37 +546,3 @@ class ExecuteCondaEnvironmentCommand(CondaCommand):
 
         with self:
             self.window.run_command('exec', kwargs)
-
-
-class OpenCondaReplCommand(CondaCommand):
-    """Open a REPL tab within the activated Conda environment."""
-
-    def run(self, open_file='$file'):
-        """Display 'Conda: Open REPL' in Sublime Text's command palette.
-
-        When 'Conda: Open REPL' is clicked by the user, a new tab is opened with a REPL of the opened file in the current environment.
-        """
-        environment_path = self.project_data['conda_environment']
-        executable_path = "{}\\{}".format(os.path.expanduser(environment_path), "python")
-        environment = self.retrieve_environment_name(environment_path)
-
-        cmd_list = [executable_path,  '-u', '-i']
-
-        if open_file:
-            cmd_list.append(open_file)
-
-        self.repl_open(cmd_list, environment)
-
-    def repl_open(self, cmd_list, environment):
-        """Open a SublimeREPL using provided commands"""
-        self.window.run_command(
-            'repl_open', {
-                'encoding': 'utf8',
-                'type': 'subprocess',
-                'cmd': cmd_list,
-                'cwd': '$file_path',
-                'syntax': 'Packages/Python/Python.tmLanguage',
-                'view_id': '*REPL* [python]',
-                'external_id': environment,
-            }
-        )

--- a/commands.py
+++ b/commands.py
@@ -247,7 +247,13 @@ class OpenCondaReplCommand(CondaCommand):
         When 'Conda: Open REPL' is clicked by the user, a new tab is opened with a REPL of the opened file in the current environment.
         """
         environment_path = self.project_data['conda_environment']
-        executable_path = "{}\\{}".format(os.path.expanduser(environment_path), "python")
+
+        if sys.platform == 'win32':
+            executable = 'python'
+        else:
+            executable = os.path.join('bin', 'python')
+
+        executable_path = os.path.join(os.path.expanduser(environment_path), executable)
         environment = self.retrieve_environment_name(environment_path)
 
         cmd_list = [executable_path,  '-u', '-i']

--- a/commands.py
+++ b/commands.py
@@ -249,7 +249,7 @@ class OpenCondaReplCommand(CondaCommand):
         environment_path = self.project_data['conda_environment']
 
         if sys.platform == 'win32':
-            executable = 'python'
+            executable = 'python.exe'
         else:
             executable = os.path.join('bin', 'python')
 

--- a/commands.py
+++ b/commands.py
@@ -512,3 +512,37 @@ class ExecuteCondaEnvironmentCommand(CondaCommand):
 
         with self:
             self.window.run_command('exec', kwargs)
+
+
+class OpenCondaReplCommand(CondaCommand):
+    """Open a REPL tab within the activated Conda environment."""
+
+    def run(self, open_file='$file'):
+        """Display 'Conda: Open REPL' in Sublime Text's command palette.
+
+        When 'Conda: Open REPL' is clicked by the user, a new tab is opened with a REPL of the opened file in the current environment.
+        """
+        environment_path = self.project_data['conda_environment']
+        executable_path = "{}\\{}".format(os.path.expanduser(environment_path), "python")
+        environment = self.retrieve_environment_name(environment_path)
+
+        cmd_list = [executable_path,  '-u', '-i']
+
+        if open_file:
+            cmd_list.append(open_file)
+
+        self.repl_open(cmd_list, environment)
+
+    def repl_open(self, cmd_list, environment):
+        """Open a SublimeREPL using provided commands"""
+        self.window.run_command(
+            'repl_open', {
+                'encoding': 'utf8',
+                'type': 'subprocess',
+                'cmd': cmd_list,
+                'cwd': '$file_path',
+                'syntax': 'Packages/Python/Python.tmLanguage',
+                'view_id': '*REPL* [python]',
+                'external_id': environment,
+            }
+        )


### PR DESCRIPTION
SublimeREPL unfortunately doesn't work with Conda environments in a simple manner - you'd have to create a new build or constantly change the interpreter for different environments. I added an "Open REPL" command (mostly taken from stackoverflow and edited to fit the Conda context) - the command uses the interpreter of the active environment and opens a REPL window for the currently opened file. 

It's quite simple but I think it'll be useful. Ideally, I would like the REPL to be reusable i.e. if you run the command repeatedly for the same environment, the same REPL window is updated, but currently a new window is opened each time. It seemed that the way SublimeREPL achieved that was in a rather complicated way though, so I'll see if I can implement that in the future.