### PR TITLE
Add saving, ui, and syntax settings to REPL

### DIFF
--- a/Conda (Linux).sublime-settings
+++ b/Conda (Linux).sublime-settings
@@ -15,6 +15,14 @@
     // configuration is the path to conda's configuration file
     "configuration": "~/.condarc",
 
+    // open repl in second row tab below current file,
+    // closing any existing tabs in that area
+    // assumes files are kept in group 0 (typical)
+    "repl_nice_ui": true,
+
+    // save the current file (if dirty) when opening repl
+    "repl_save_dirty": true,
+
     // syntax highlighting for Open REPL command
     // commonly a choice between 'Text/Plain text' and 'Python/Python'
     "repl_syntax": "Packages/Text/Plain text.tmLanguage"

--- a/Conda (Linux).sublime-settings
+++ b/Conda (Linux).sublime-settings
@@ -18,7 +18,7 @@
     // open repl in second row tab below current file,
     // closing any existing tabs in that area
     // assumes files are kept in group 0 (typical)
-    "repl_nice_ui": true,
+    "repl_open_row": true,
 
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,

--- a/Conda (Linux).sublime-settings
+++ b/Conda (Linux).sublime-settings
@@ -13,5 +13,9 @@
     "architecture": "64",
 
     // configuration is the path to conda's configuration file
-    "configuration": "~/.condarc"
+    "configuration": "~/.condarc",
+
+    // syntax highlighting for Open REPL command
+    // commonly a choice between 'Text/Plain text' and 'Python/Python'
+    "repl_syntax": "Packages/Text/Plain text.tmLanguage"
 }

--- a/Conda (Linux).sublime-settings
+++ b/Conda (Linux).sublime-settings
@@ -18,7 +18,7 @@
     // open repl in second row tab below current file,
     // closing any existing tabs in that area
     // assumes files are kept in group 0 (typical)
-    "repl_open_row": true,
+    "repl_open_row": false,
 
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,

--- a/Conda (OSX).sublime-settings
+++ b/Conda (OSX).sublime-settings
@@ -15,6 +15,14 @@
     // configuration is the path to conda's configuration file
     "configuration": "~/.condarc",
 
+    // open repl in second row tab below current file,
+    // closing any existing tabs in that area
+    // assumes files are kept in group 0 (typical)
+    "repl_nice_ui": true,
+
+    // save the current file (if dirty) when opening repl
+    "repl_save_dirty": true,
+
     // syntax highlighting for Open REPL command
     // commonly a choice between 'Text/Plain text' and 'Python/Python'
     "repl_syntax": "Packages/Text/Plain text.tmLanguage"

--- a/Conda (OSX).sublime-settings
+++ b/Conda (OSX).sublime-settings
@@ -18,7 +18,7 @@
     // open repl in second row tab below current file,
     // closing any existing tabs in that area
     // assumes files are kept in group 0 (typical)
-    "repl_nice_ui": true,
+    "repl_open_row": true,
 
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,

--- a/Conda (OSX).sublime-settings
+++ b/Conda (OSX).sublime-settings
@@ -13,5 +13,9 @@
     "architecture": "64",
 
     // configuration is the path to conda's configuration file
-    "configuration": "~/.condarc"
+    "configuration": "~/.condarc",
+
+    // syntax highlighting for Open REPL command
+    // commonly a choice between 'Text/Plain text' and 'Python/Python'
+    "repl_syntax": "Packages/Text/Plain text.tmLanguage"
 }

--- a/Conda (OSX).sublime-settings
+++ b/Conda (OSX).sublime-settings
@@ -18,7 +18,7 @@
     // open repl in second row tab below current file,
     // closing any existing tabs in that area
     // assumes files are kept in group 0 (typical)
-    "repl_open_row": true,
+    "repl_open_row": false,
 
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,

--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -15,6 +15,14 @@
     // configuration is the path to conda's configuration file
     "configuration": "~\\.condarc",
 
+    // open repl in second row tab below current file,
+    // closing any existing tabs in that area
+    // assumes files are kept in group 0 (typical)
+    "repl_nice_ui": true,
+
+    // save the current file (if dirty) when opening repl
+    "repl_save_dirty": true,
+
     // syntax highlighting for Open REPL command
     // commonly a choice between 'Text/Plain text' and 'Python/Python'
     "repl_syntax": "Packages/Text/Plain text.tmLanguage",

--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -15,6 +15,10 @@
     // configuration is the path to conda's configuration file
     "configuration": "~\\.condarc",
 
+    // syntax highlighting for Open REPL command
+    // commonly a choice between 'Text/Plain text' and 'Python/Python'
+    "repl_syntax": "Packages/Text/Plain text.tmLanguage",
+
     // when true, the scripts will be run through the shell
     // If your code has a GUI (e.g. a matplotlib plot),
     // this needs to be true, otherwise Windows suppresses it.

--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -18,7 +18,7 @@
     // open repl in second row tab below current file,
     // closing any existing tabs in that area
     // assumes files are kept in group 0 (typical)
-    "repl_nice_ui": true,
+    "repl_open_row": true,
 
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,

--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -18,7 +18,7 @@
     // open repl in second row tab below current file,
     // closing any existing tabs in that area
     // assumes files are kept in group 0 (typical)
-    "repl_open_row": true,
+    "repl_open_row": false,
 
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ working on projects that require a GUI to open (such as showing a matplotlib plo
 Usage
 =====
 
-Once installed, a ``Conda`` build system will appear in the build sytem menu and conda's commands will be located inside the command palette. The ``Conda`` build system must be selected in order to use the commands. These commands include ``Create Environment``, ``Remove Environment``, ``List Environments``, ``Activate Environment``, ``Deactivate Environment``, ``Install Package``, ``Remove Package``, ``List Packages``, ``Add Channel Source``, ``Remove Channel Source``, and ``List Channel Sources``.
+Once installed, a ``Conda`` build system will appear in the build sytem menu and conda's commands will be located inside the command palette. The ``Conda`` build system must be selected in order to use the commands. These commands include ``Create Environment``, ``Remove Environment``, ``List Environments``, ``Activate Environment``, ``Deactivate Environment`` ``Open REPL``, ``Install Package``, ``Remove Package``, ``List Packages``, ``Add Channel Source``, ``Remove Channel Source``, and ``List Channel Sources``. Command names for key bindings can be found `here <Default.sublime-commands>`_.
 
 **Conda: Create Environment**
 
@@ -67,6 +67,12 @@ activated. The selected conda environment will then be used in the build system.
 When selected from the command palette, `Conda: Dectivate Environment` will
 display in the command palette the current active environment. When the environment
 is selected, the build system will revert back to the Python that is located on PATH.
+
+**Conda: Open REPL**
+
+When selected from the command palette, `Conda: Open REPL` will
+open a REPL tab with the currently opened file within the activated Conda
+environment.
 
 **Conda: Install Package**
 

--- a/commands.py
+++ b/commands.py
@@ -286,7 +286,7 @@ class OpenCondaReplCommand(CondaCommand):
                 'type': 'subprocess',
                 'cmd': cmd_list,
                 'cwd': '$file_path',
-                'syntax': 'Packages/Python/Python.tmLanguage',
+                'syntax': self.settings.get('repl_syntax'),
                 'view_id': '*REPL* [python]',
                 'external_id': environment,
             }

--- a/commands.py
+++ b/commands.py
@@ -263,11 +263,11 @@ class OpenCondaReplCommand(CondaCommand):
         with a REPL of the opened file in the current environment.
         """
         settings = self.settings
-        repl_nice_ui = settings.get('repl_nice_ui')
+        repl_open_row = settings.get('repl_open_row')
         repl_save_dirty = open_file and settings.get('repl_save_dirty')
         repl_syntax = settings.get('repl_syntax')
 
-        if repl_nice_ui:
+        if repl_open_row:
             # set layout to 2 rows
             if (self.window.num_groups() != 2):
                 self.window.run_command(
@@ -310,7 +310,7 @@ class OpenCondaReplCommand(CondaCommand):
         # open the repl
         self.repl_open(cmd_list, environment, repl_syntax)
 
-        if repl_nice_ui:
+        if repl_open_row:
             # move the interpreter into group 1, with focus
             self.window.run_command(
                 'move_to_group', {'group': pythonInterpretersGroup}

--- a/commands.py
+++ b/commands.py
@@ -350,6 +350,7 @@ class REPLViewEventListener(sublime_plugin.ViewEventListener):
         return settings.get("conda_repl_new_row", False)
 
     def __init__(self, view):
+        # need to capture window during construction
         self.window = view.window()
         super().__init__(view)
 
@@ -360,10 +361,10 @@ class REPLViewEventListener(sublime_plugin.ViewEventListener):
             # only remove row when empty
             if (self.window.num_groups() == 2) and len(views) == 0:
                 self.window.run_command(
-                    'set_layout',
-                    {"cols":[0.0, 1.0],
-                     "rows":[0.0, 1.0],
-                     "cells":[[0, 0, 1, 1]]
+                    'set_layout', {
+                        'cols':[0.0, 1.0],
+                        'rows':[0.0, 1.0],
+                        'cells':[[0, 0, 1, 1]]
                     }
                 )
 

--- a/commands.py
+++ b/commands.py
@@ -259,34 +259,82 @@ class OpenCondaReplCommand(CondaCommand):
     def run(self, open_file='$file'):
         """Display 'Conda: Open REPL' in Sublime Text's command palette.
 
-        When 'Conda: Open REPL' is clicked by the user, a new tab is opened with a REPL of the opened file in the current environment.
+        When 'Conda: Open REPL' is clicked by the user, a new tab is opened
+        with a REPL of the opened file in the current environment.
         """
-        environment_path = self.project_data['conda_environment']
+        settings = self.settings
+        repl_nice_ui = settings.get('repl_nice_ui')
+        repl_save_dirty = open_file and settings.get('repl_save_dirty')
+        repl_syntax = settings.get('repl_syntax')
 
+        if repl_nice_ui:
+            # set layout to 2 rows
+            if (self.window.num_groups() != 2):
+                self.window.run_command(
+                    'set_layout', {
+                        'cols':[0.0, 1.0],
+                        'rows':[0.0, 0.5, 1.0],
+                        'cells':[[0, 0, 1, 1], [0, 1, 1, 2]]
+                    }
+                )
+
+            # return focus to file
+            pythonEditorsGroup = 0
+            self.window.focus_group(pythonEditorsGroup)
+
+            # close old Python interpreters, if any
+            pythonInterpretersGroup = 1
+            for view in self.window.views_in_group(pythonInterpretersGroup):
+                view.close()
+
+        if repl_save_dirty:
+            # save file (if necessary) in current view
+            view = self.window.active_view()
+            if view.is_dirty():
+                view.run_command('save')
+
+        # build the command list
         if sys.platform == 'win32':
             executable = 'python.exe'
         else:
             executable = os.path.join('bin', 'python')
 
+        environment_path = self.project_data['conda_environment']
         executable_path = os.path.join(os.path.expanduser(environment_path), executable)
         environment = self.retrieve_environment_name(environment_path)
-
         cmd_list = [executable_path,  '-u', '-i']
 
         if open_file:
             cmd_list.append(open_file)
 
-        self.repl_open(cmd_list, environment)
+        # open the repl
+        self.repl_open(cmd_list, environment, repl_syntax)
 
-    def repl_open(self, cmd_list, environment):
+        if repl_nice_ui:
+            # move the interpreter into group 1, with focus
+            self.window.run_command(
+                'move_to_group', {'group': pythonInterpretersGroup}
+            )
+
+            # set view to top of repl window in case anything is printed above
+            view = self.window.active_view()
+            layout_width, layout_height = view.layout_extent()
+            window_width, window_height = view.viewport_extent()
+            new_top = layout_height - window_height
+            view.set_viewport_position((0, max(new_top, 0)))
+
+    def repl_open(self, cmd_list, environment, syntax=None):
         """Open a SublimeREPL using provided commands"""
+        if syntax is None:
+            syntax = self.settings.get('repl_syntax')
+
         self.window.run_command(
             'repl_open', {
                 'encoding': 'utf8',
                 'type': 'subprocess',
                 'cmd': cmd_list,
                 'cwd': '$file_path',
-                'syntax': self.settings.get('repl_syntax'),
+                'syntax': syntax,
                 'view_id': '*REPL* [python]',
                 'external_id': environment,
             }


### PR DESCRIPTION
# Summary

I've used a small custom sublime repl plugin for python for years, and after discovering this package I think it'd be nice to include the couple of neat things I've enjoyed with my repl setup. Namely, saving the file before opening the repl, opening the repl in a second row tab below the file, and closing any still open repls in that second row (if they haven't been moved to the main row/window, in which case they're kept open). I made these features optional by putting them into settings, and I defaulted them to true since I think they're quite handy, but they can default to false if wanted.

I also added a setting for the syntax highlighting of the repl, since I noticed that it is currently set to python syntax. This is not common for python repls, which are usually highlighted as plain text, since python highlighting causes text in the repl to show up weird. I made the setting default to plain text to reflect this, leaving the option to still use python syntax, but again the default could be changed back. Note that without adding this setting the only way to change the highlighting is to change the global SublimeREPL setting (as far as I know).

# Changes

- Setting `repl_save_dirty` to save the file when opening the repl
- Setting `repl_nice_ui` to open the repl in a second row tab
- Setting `repl_syntax` to control syntax highlighting, defaulted to plain text