### PR TITLE
REPL fixes and improvements

### DIFF
--- a/Conda (Linux).sublime-settings
+++ b/Conda (Linux).sublime-settings
@@ -24,6 +24,6 @@
     "repl_save_dirty": true,
 
     // syntax highlighting for Open REPL command
-    // commonly a choice between 'Text/Plain text' and 'Python/Python'
-    "repl_syntax": "Packages/Text/Plain text.tmLanguage"
+    // choice between 'python' and 'plaintext'
+    "repl_syntax": "python"
 }

--- a/Conda (Linux).sublime-settings
+++ b/Conda (Linux).sublime-settings
@@ -20,6 +20,10 @@
     // assumes files are kept in group 0 (typical)
     "repl_open_row": false,
 
+    // when opening a repl using repl_open_row, close any
+    // existing conda repls in the second row first
+    "repl_row_close_existing": false,
+
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,
 

--- a/Conda (OSX).sublime-settings
+++ b/Conda (OSX).sublime-settings
@@ -24,6 +24,6 @@
     "repl_save_dirty": true,
 
     // syntax highlighting for Open REPL command
-    // commonly a choice between 'Text/Plain text' and 'Python/Python'
-    "repl_syntax": "Packages/Text/Plain text.tmLanguage"
+    // choice between 'python' and 'plaintext'
+    "repl_syntax": "python"
 }

--- a/Conda (OSX).sublime-settings
+++ b/Conda (OSX).sublime-settings
@@ -20,6 +20,10 @@
     // assumes files are kept in group 0 (typical)
     "repl_open_row": false,
 
+    // when opening a repl using repl_open_row, close any
+    // existing conda repls in the second row first
+    "repl_row_close_existing": false,
+
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,
 

--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -15,6 +15,15 @@
     // configuration is the path to conda's configuration file
     "configuration": "~\\.condarc",
 
+    // when true, the scripts will be run through the shell
+    // If your code has a GUI (e.g. a matplotlib plot),
+    // this needs to be true, otherwise Windows suppresses it.
+    "run_through_shell": false,
+
+    // when true, the script execution will be handed over to
+    // the pythonw executable, instead of python
+    "use_pythonw": false,
+
     // open repl in second row tab below current file,
     // closing any existing tabs in that area
     // assumes files are kept in group 0 (typical)
@@ -29,14 +38,5 @@
 
     // syntax highlighting for Open REPL command
     // choice between 'python' and 'plaintext'
-    "repl_syntax": "python",
-
-    // when true, the scripts will be run through the shell
-    // If your code has a GUI (e.g. a matplotlib plot),
-    // this needs to be true, otherwise Windows suppresses it.
-    "run_through_shell": false,
-
-    // when true, the script execution will be handed over to
-    // the pythonw executable, instead of python
-    "use_pythonw": false
+    "repl_syntax": "python"
 }

--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -20,6 +20,10 @@
     // assumes files are kept in group 0 (typical)
     "repl_open_row": false,
 
+    // when opening a repl using repl_open_row, close any
+    // existing conda repls in the second row first
+    "repl_row_close_existing": false,
+
     // save the current file (if dirty) when opening repl
     "repl_save_dirty": true,
 

--- a/Conda (Windows).sublime-settings
+++ b/Conda (Windows).sublime-settings
@@ -24,8 +24,8 @@
     "repl_save_dirty": true,
 
     // syntax highlighting for Open REPL command
-    // commonly a choice between 'Text/Plain text' and 'Python/Python'
-    "repl_syntax": "Packages/Text/Plain text.tmLanguage",
+    // choice between 'python' and 'plaintext'
+    "repl_syntax": "python",
 
     // when true, the scripts will be run through the shell
     // If your code has a GUI (e.g. a matplotlib plot),

--- a/commands.py
+++ b/commands.py
@@ -264,6 +264,7 @@ class OpenCondaReplCommand(CondaCommand):
         """
         settings = self.settings
         repl_open_row = settings.get('repl_open_row')
+        repl_row_close_existing = settings.get('repl_row_close_existing')
         repl_save_dirty = open_file and settings.get('repl_save_dirty')
         repl_syntax = settings.get('repl_syntax')
 
@@ -282,19 +283,22 @@ class OpenCondaReplCommand(CondaCommand):
             editor_group = 0
             self.window.focus_group(editor_group)
 
-            # close old repls, if any
             repl_group = 1
-            index = None # grab index of first repl, if one exists
-            for view in self.window.views_in_group(repl_group):
-                settings = view.settings()
-                if settings.get("conda_repl_new_row", False):
-                    index = index or self.window.get_view_index(view)
-                    # make sure close event does not mess with layout
-                    settings.set("conda_repl_new_row", False)
-                    view.close()
-                    # if there's another tab in that group, it will focus
-                    # there after closing, so return focus to main file
-                    self.window.focus_group(editor_group)
+            index = None
+
+            if repl_row_close_existing:
+                # close old repls, if any
+                for view in self.window.views_in_group(repl_group):
+                    settings = view.settings()
+                    if settings.get("conda_repl_new_row", False):
+                        # grab index of first repl, if one exists
+                        index = index or self.window.get_view_index(view)
+                        # make sure close event does not mess with layout
+                        settings.set("conda_repl_new_row", False)
+                        view.close()
+                        # if there's another tab in that group, it will focus
+                        # there after closing, so return focus to main file
+                        self.window.focus_group(editor_group)
 
         if repl_save_dirty:
             # save file (if necessary) in current view

--- a/commands.py
+++ b/commands.py
@@ -285,9 +285,14 @@ class OpenCondaReplCommand(CondaCommand):
             # close old Python interpreters, if any
             repl_group = 1
             for view in self.window.views_in_group(repl_group):
-                # make sure close event does not mess with layout
-                view.settings().set("conda_repl_new_row", False)
-                view.close()
+                settings = view.settings()
+                if settings.get("conda_repl_new_row", False):
+                    # make sure close event does not mess with layout
+                    settings.set("conda_repl_new_row", False)
+                    view.close()
+                    # if there's another tab in that group, it will focus
+                    # there after closing, so return focus to main file
+                    self.window.focus_group(editor_group)
 
         if repl_save_dirty:
             # save file (if necessary) in current view

--- a/commands.py
+++ b/commands.py
@@ -282,11 +282,13 @@ class OpenCondaReplCommand(CondaCommand):
             editor_group = 0
             self.window.focus_group(editor_group)
 
-            # close old Python interpreters, if any
+            # close old repls, if any
             repl_group = 1
+            index = None # grab index of first repl, if one exists
             for view in self.window.views_in_group(repl_group):
                 settings = view.settings()
                 if settings.get("conda_repl_new_row", False):
+                    index = index or self.window.get_view_index(view)
                     # make sure close event does not mess with layout
                     settings.set("conda_repl_new_row", False)
                     view.close()
@@ -318,13 +320,18 @@ class OpenCondaReplCommand(CondaCommand):
         self.repl_open(cmd_list, environment, repl_syntax)
 
         if repl_open_row:
-            # move the interpreter into group 1, with focus
+            # move the repl into group, with focus
             self.window.run_command(
                 'move_to_group', {'group': repl_group}
             )
 
-            # set view to top of repl window in case anything is printed above
             view = self.window.active_view()
+
+            # put repl in same spot as old repl if one existed
+            if index is not None:
+                self.window.set_view_index(view, *index)
+
+            # set view to top of repl window in case anything is printed above
             layout_width, layout_height = view.layout_extent()
             window_width, window_height = view.viewport_extent()
             new_top = layout_height - window_height

--- a/commands.py
+++ b/commands.py
@@ -343,13 +343,21 @@ class OpenCondaReplCommand(CondaCommand):
         if syntax is None:
             syntax = self.settings.get('repl_syntax')
 
+        syntaxpath = "Packages/%s.tmLanguage"
+        if syntax == "python":
+            syntaxpath = syntaxpath % "Python/Python"
+        elif syntax == "plaintext":
+            syntaxpath = syntaxpath % "Text/Plain text"
+        else:
+            raise ValueError("Unrecognized syntax setting '%s'" % (syntax,))
+
         self.window.run_command(
             'repl_open', {
                 'encoding': 'utf8',
                 'type': 'subprocess',
                 'cmd': cmd_list,
                 'cwd': '$file_path',
-                'syntax': syntax,
+                'syntax': syntaxpath,
                 'view_id': '*REPL* [python]',
                 'external_id': environment,
             }

--- a/commands.py
+++ b/commands.py
@@ -347,13 +347,14 @@ class OpenCondaReplCommand(CondaCommand):
         if syntax is None:
             syntax = self.settings.get('repl_syntax')
 
-        syntaxpath = "Packages/%s.tmLanguage"
+        syntaxname = "Python/Python" # meaningful fallback
         if syntax == "python":
-            syntaxpath = syntaxpath % "Python/Python"
+            syntaxname = "Python/Python"
         elif syntax == "plaintext":
-            syntaxpath = syntaxpath % "Text/Plain text"
+            syntaxname = "Text/Plain text"
         else:
-            raise ValueError("Unrecognized syntax setting '%s'" % (syntax,))
+            print("Conda Open REPL: Unrecognized syntax '{}'".format(syntax))
+        syntaxpath = "Packages/{}.tmLanguage".format(syntaxname)
 
         self.window.run_command(
             'repl_open', {

--- a/commands.py
+++ b/commands.py
@@ -285,6 +285,8 @@ class OpenCondaReplCommand(CondaCommand):
             # close old Python interpreters, if any
             repl_group = 1
             for view in self.window.views_in_group(repl_group):
+                # make sure close event does not mess with layout
+                view.settings().set("conda_repl_new_row", False)
                 view.close()
 
         if repl_save_dirty:
@@ -372,10 +374,10 @@ class REPLViewEventListener(sublime_plugin.ViewEventListener):
         """Remove row if conditions are met"""
         if self.remove_row:
             self.window.run_command(
-                'set_layout',
-                {"cols":[0.0, 1.0],
-                 "rows":[0.0, 1.0],
-                 "cells":[[0, 0, 1, 1]]
+                'set_layout', {
+                    'cols':[0.0, 1.0],
+                    'rows':[0.0, 1.0],
+                    'cells':[[0, 0, 1, 1]]
                 }
             )
 

--- a/commands.py
+++ b/commands.py
@@ -346,17 +346,20 @@ class REPLViewEventListener(sublime_plugin.ViewEventListener):
     """Event to remove entire row when repl is last tab closed"""
     @classmethod
     def is_applicable(cls, settings):
-        # only activate close event for conda repls in new row
+        """Only activate close event for conda repls in new row"""
         return settings.get("conda_repl_new_row", False)
 
     def __init__(self, view):
-        # need to grab window since it is None during on_close
+        """Grab window since it is None during on_close"""
         self.window = view.window()
         super().__init__(view)
 
     def on_pre_close(self):
-        # determine if we should remove the row:
-        # number groups unchanged, view in group, and group empty
+        """Determine if row should be removed:
+            - number groups unchanged
+            - view in group
+            - group empty
+        """
         window, view = self.window, self.view
         repl_group = 1
         self.remove_row = (
@@ -366,6 +369,7 @@ class REPLViewEventListener(sublime_plugin.ViewEventListener):
         )
 
     def on_close(self):
+        """Remove row if conditions are met"""
         if self.remove_row:
             self.window.run_command(
                 'set_layout',

--- a/commands.py
+++ b/commands.py
@@ -355,18 +355,17 @@ class REPLViewEventListener(sublime_plugin.ViewEventListener):
         super().__init__(view)
 
     def on_close(self):
-        if self.window is not None:
-            pythonInterpretersGroup = 1
-            views = self.window.views_in_group(pythonInterpretersGroup)
-            # only remove row when empty
-            if (self.window.num_groups() == 2) and len(views) == 0:
-                self.window.run_command(
-                    'set_layout', {
-                        'cols':[0.0, 1.0],
-                        'rows':[0.0, 1.0],
-                        'cells':[[0, 0, 1, 1]]
-                    }
-                )
+        pythonInterpretersGroup = 1
+        views = self.window.views_in_group(pythonInterpretersGroup)
+        # only remove row when empty
+        if (self.window.num_groups() == 2) and len(views) == 0:
+            self.window.run_command(
+                'set_layout', {
+                    'cols':[0.0, 1.0],
+                    'rows':[0.0, 1.0],
+                    'cells':[[0, 0, 1, 1]]
+                }
+            )
 
 
 class ListCondaPackageCommand(CondaCommand):


### PR DESCRIPTION
# Summary

Sorry for the second pull request. I just discovered a bug and some other opportunities for improvements, so I wanted to get some changes in. Everything is mainly about when and how to close tabs.

# Changes

- **Bug fix**: opening a repl while one was already open in the second row got rid of the layout and reverted to a single-cell layout due to the close event. The intended behavior is to keep the row there, close the existing repl, and open a new one in its place. To fix this, change the setting to avoid running the close event during the Open REPL command.
- Only close repl tabs in the second row, ignore other files
- Only remove second row if repl is still in that group on close
- Put new repl in same spot as old repl if one exists, in case there were multiple files in the group